### PR TITLE
Expose raw BLE adv data and rssi outside of the package

### DIFF
--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
@@ -44,13 +44,13 @@ public extension CentralManager {
 
     // This method doesn't need to be marked async, but it prevents a signature collision
     @available(iOS 13, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
-    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil) async -> AsyncStream<Peripheral> {
+    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil) async -> AsyncStream<ScanResult> {
         .init { cont in
             var timer: Timer?
             let subscription = eventSubscriptions.queue { event, done in
                 switch event {
-                case .discovered(let peripheral, _, _):
-                    cont.yield(peripheral)
+                case .discovered(let peripheral, let advData, let rssi):
+                    cont.yield(ScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
                 case .stopScan:
                     done()
                     cont.finish()

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
@@ -3,7 +3,7 @@ import CoreBluetooth
 
 public extension CentralManager {
     @available(iOS 13, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
-    func waitUntilReady(timeout: TimeInterval) async throws {
+    func waitUntilReady(timeout: TimeInterval = Double.infinity) async throws {
         try await withCheckedThrowingContinuation { cont in
             self.waitUntilReady(timeout: timeout) { result in
                 cont.resume(with: result)

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
@@ -44,13 +44,13 @@ public extension CentralManager {
 
     // This method doesn't need to be marked async, but it prevents a signature collision
     @available(iOS 13, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
-    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil) async -> AsyncStream<ScanResult> {
+    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil) async -> AsyncStream<PeripheralScanResult> {
         .init { cont in
             var timer: Timer?
             let subscription = eventSubscriptions.queue { event, done in
                 switch event {
                 case .discovered(let peripheral, let advData, let rssi):
-                    cont.yield(ScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
+                    cont.yield(PeripheralScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
                 case .stopScan:
                     done()
                     cont.finish()

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+async.swift
@@ -3,9 +3,9 @@ import CoreBluetooth
 
 public extension CentralManager {
     @available(iOS 13, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
-    func waitUntilReady() async throws {
+    func waitUntilReady(timeout: TimeInterval) async throws {
         try await withCheckedThrowingContinuation { cont in
-            self.waitUntilReady { result in
+            self.waitUntilReady(timeout: timeout) { result in
                 cont.resume(with: result)
             }
         }

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreBluetooth
 
-public struct ScanResult {
+public struct PeripheralScanResult {
     let peripheral: Peripheral
     let advertisementData: [String: Any]
     let rssi: NSNumber
@@ -84,13 +84,13 @@ public extension CentralManager {
         }
     }
 
-    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil, onPeripheralFound: @escaping (ScanResult) -> Void) -> CancellableTask {
+    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil, onPeripheralFound: @escaping (PeripheralScanResult) -> Void) -> CancellableTask {
         eventQueue.sync {
             var timer: Timer?
             let subscription = eventSubscriptions.queue { event, done in
                 switch event {
                 case .discovered(let peripheral, let advData, let rssi):
-                    onPeripheralFound(ScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
+                    onPeripheralFound(PeripheralScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
                 case .stopScan:
                     done()
                 default:

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
@@ -1,6 +1,12 @@
 import Foundation
 import CoreBluetooth
 
+public struct ScanResult {
+    let peripheral: Peripheral
+    let advertisementData: [String: Any]
+    let rssi: NSNumber
+}
+
 public extension CentralManager {
     func waitUntilReady(completionHandler: @escaping (Result<Void, Error>) -> Void) {
         eventQueue.async { [self] in
@@ -78,13 +84,13 @@ public extension CentralManager {
         }
     }
 
-    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil, onPeripheralFound: @escaping (Peripheral) -> Void) -> CancellableTask {
+    func scanForPeripherals(withServices services: [CBUUID]? = nil, timeout: TimeInterval? = nil, options: [String: Any]? = nil, onPeripheralFound: @escaping (ScanResult) -> Void) -> CancellableTask {
         eventQueue.sync {
             var timer: Timer?
             let subscription = eventSubscriptions.queue { event, done in
                 switch event {
-                case .discovered(let peripheral, _, _):
-                    onPeripheralFound(peripheral)
+                case .discovered(let peripheral, let advData, let rssi):
+                    onPeripheralFound(ScanResult(peripheral: peripheral, advertisementData: advData, rssi: rssi))
                 case .stopScan:
                     done()
                 default:

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
@@ -2,9 +2,9 @@ import Foundation
 import CoreBluetooth
 
 public struct PeripheralScanResult {
-    let peripheral: Peripheral
-    let advertisementData: [String: Any]
-    let rssi: NSNumber
+    public let peripheral: Peripheral
+    public let advertisementData: [String: Any]
+    public let rssi: NSNumber
 }
 
 public extension CentralManager {

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
@@ -47,7 +47,7 @@ public extension CentralManager {
             if timeout != .infinity {
                 let timeoutTimer = Timer(fire: Date() + timeout, interval: 0, repeats: false) { _ in
                     task.cancel()
-                    completionHandler(.failure(CBError(.connectionTimeout)))
+                    completionHandler(.failure(CentralError.poweredOff))
                 }
                 timer = timeoutTimer
                 RunLoop.main.add(timeoutTimer, forMode: .default)

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager+callback.swift
@@ -8,7 +8,7 @@ public struct PeripheralScanResult {
 }
 
 public extension CentralManager {
-    func waitUntilReady(timeout: TimeInterval, completionHandler: @escaping (Result<Void, Error>) -> Void) {
+    func waitUntilReady(timeout: TimeInterval = Double.infinity, completionHandler: @escaping (Result<Void, Error>) -> Void) {
         eventQueue.async { [self] in
             guard state != .poweredOn else {
                 completionHandler(.success(Void()))

--- a/Sources/SwiftBluetooth/CentralManager/CentralManagerError.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManagerError.swift
@@ -4,4 +4,5 @@ public enum CentralError: Error {
     case unknown
     case unauthorized
     case unavailable
+    case poweredOff
 }


### PR DESCRIPTION
It is important to expose the adv data and RSSI outside of the library for the discovered peripherals. This information contains critical data in the adv data that will be needed for implementors of this library