### PR TITLE
Correct Spelling in function names

### DIFF
--- a/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueue.swift
+++ b/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueue.swift
@@ -25,7 +25,7 @@ internal final class AsyncSubscriptionQueue<Value> {
         return item
     }
 
-    func recieve(_ value: Value) {
+    func receive(_ value: Value) {
         dispatchQueue.async {
             for item in self.items.reversed() {
                 item.block(value, item.cancel)
@@ -38,4 +38,19 @@ internal final class AsyncSubscriptionQueue<Value> {
             self.items.removeAll(where: { $0 == item })
         }
     }
+}
+
+// MARK: Deprecated
+
+extension AsyncSubscriptionQueue {
+
+    @available(*, deprecated, renamed: "receive")
+    func recieve(_ value: Value) {
+        dispatchQueue.async {
+            for item in self.items.reversed() {
+                item.block(value, item.cancel)
+            }
+        }
+    }
+
 }

--- a/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueueMap.swift
+++ b/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueueMap.swift
@@ -33,6 +33,20 @@ internal final class AsyncSubscriptionQueueMap<Key, Value> where Key: Hashable {
         return item.queue(block: block, completion: completion)
     }
 
+    func receive(key: Key, withValue value: Value) {
+        dispatchQueue.async {
+            guard let queue = self.items[key] else { return }
+
+            queue.receive(value)
+        }
+    }
+}
+
+// MARK: Deprecated
+
+extension AsyncSubscriptionQueueMap {
+
+    @available(*, deprecated, renamed: "receive")
     func recieve(key: Key, withValue value: Value) {
         dispatchQueue.async {
             guard let queue = self.items[key] else { return }
@@ -40,4 +54,5 @@ internal final class AsyncSubscriptionQueueMap<Key, Value> where Key: Hashable {
             queue.receive(value)
         }
     }
+
 }

--- a/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueueMap.swift
+++ b/Sources/SwiftBluetooth/Async/AsyncSubscriptionQueueMap.swift
@@ -37,7 +37,7 @@ internal final class AsyncSubscriptionQueueMap<Key, Value> where Key: Hashable {
         dispatchQueue.async {
             guard let queue = self.items[key] else { return }
 
-            queue.recieve(value)
+            queue.receive(value)
         }
     }
 }

--- a/Sources/SwiftBluetooth/CentralManager/CentralManager.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManager.swift
@@ -73,7 +73,7 @@ public extension CentralManager {
     }
 
     func stopScan() {
-        eventSubscriptions.recieve(.stopScan)
+        eventSubscriptions.receive(.stopScan)
         centralManager.stopScan()
     }
 }

--- a/Sources/SwiftBluetooth/CentralManager/CentralManagerDelegateWrapper.swift
+++ b/Sources/SwiftBluetooth/CentralManager/CentralManagerDelegateWrapper.swift
@@ -15,7 +15,7 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         parent.delegate?.centralManagerDidUpdateState(parent)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.stateUpdated(parent.state))
+            parent.eventSubscriptions.receive(.stateUpdated(parent.state))
         }
     }
 
@@ -27,7 +27,7 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         parent.delegate?.centralManager(parent, didConnect: peripheral)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.connected(peripheral))
+            parent.eventSubscriptions.receive(.connected(peripheral))
         }
     }
 
@@ -45,8 +45,8 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         // parent.removePeripheral(peripheral.cbPeripheral)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.disconnected(peripheral, error))
-            peripheral.eventSubscriptions.recieve(.didDisconnect(error))
+            parent.eventSubscriptions.receive(.disconnected(peripheral, error))
+            peripheral.eventSubscriptions.receive(.didDisconnect(error))
         }
     }
 
@@ -57,7 +57,7 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         parent.delegate?.centralManager(parent, didFailToConnect: peripheral, error: error)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.failToConnect(peripheral, error))
+            parent.eventSubscriptions.receive(.failToConnect(peripheral, error))
         }
     }
 
@@ -69,7 +69,7 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         parent.delegate?.centralManager(parent, didDiscover: peripheral, advertisementData: advertisementData, rssi: RSSI)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.discovered(peripheral, advertisementData, RSSI))
+            parent.eventSubscriptions.receive(.discovered(peripheral, advertisementData, RSSI))
         }
     }
 
@@ -79,7 +79,7 @@ class CentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         parent.delegate?.centralManager(parent, willRestoreState: dict)
 
         parent.eventQueue.async {
-            parent.eventSubscriptions.recieve(.restoreState(dict))
+            parent.eventSubscriptions.receive(.restoreState(dict))
         }
     }
 

--- a/Sources/SwiftBluetooth/Peripheral/PeripheralDelegateWrapper.swift
+++ b/Sources/SwiftBluetooth/Peripheral/PeripheralDelegateWrapper.swift
@@ -43,9 +43,9 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
         guard let parent = parent else { return }
 
         if let error {
-            parent.responseMap.recieve(key: characteristic.uuid, withValue: .failure(error))
+            parent.responseMap.receive(key: characteristic.uuid, withValue: .failure(error))
         } else if let value = characteristic.value {
-            parent.responseMap.recieve(key: characteristic.uuid, withValue: .success(value))
+            parent.responseMap.receive(key: characteristic.uuid, withValue: .success(value))
         }
 
         parent.delegate?.peripheral(parent, didUpdateValueFor: characteristic, error: error)
@@ -55,9 +55,9 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
         guard let parent = parent else { return }
 
         if let error {
-            parent.descriptorMap.recieve(key: descriptor.uuid, withValue: .failure(error))
+            parent.descriptorMap.receive(key: descriptor.uuid, withValue: .failure(error))
         } else {
-            parent.descriptorMap.recieve(key: descriptor.uuid, withValue: .success(descriptor.value))
+            parent.descriptorMap.receive(key: descriptor.uuid, withValue: .success(descriptor.value))
         }
 
         parent.delegate?.peripheral(parent, didUpdateValueFor: descriptor, error: error)
@@ -66,14 +66,14 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         guard let parent = parent else { return }
 
-        parent.writeMap.recieve(key: characteristic.uuid, withValue: error)
+        parent.writeMap.receive(key: characteristic.uuid, withValue: error)
         parent.delegate?.peripheral(parent, didWriteValueFor: characteristic, error: error)
     }
 
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor descriptor: CBDescriptor, error: Error?) {
         guard let parent = parent else { return }
 
-        parent.writeMap.recieve(key: descriptor.uuid, withValue: error)
+        parent.writeMap.receive(key: descriptor.uuid, withValue: error)
         parent.delegate?.peripheral(parent, didWriteValueFor: descriptor, error: error)
     }
 

--- a/Sources/SwiftBluetooth/Peripheral/PeripheralDelegateWrapper.swift
+++ b/Sources/SwiftBluetooth/Peripheral/PeripheralDelegateWrapper.swift
@@ -12,7 +12,7 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         guard let parent = parent else { return }
-        parent.eventSubscriptions.recieve(.discoveredServices(parent.services ?? [], error))
+        parent.eventSubscriptions.receive(.discoveredServices(parent.services ?? [], error))
         parent.delegate?.peripheral(parent, didDiscoverServices: error)
     }
 
@@ -29,13 +29,13 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
             parent.knownCharacteristics[characteristic.uuid] = characteristic
         }
 
-        parent.eventSubscriptions.recieve(.discoveredCharacteristics(service, service.characteristics ?? [], error))
+        parent.eventSubscriptions.receive(.discoveredCharacteristics(service, service.characteristics ?? [], error))
         parent.delegate?.peripheral(parent, didDiscoverCharacteristicsFor: service, error: error)
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverDescriptorsFor characteristic: CBCharacteristic, error: Error?) {
         guard let parent = parent else { return }
-        parent.eventSubscriptions.recieve(.discoveredDescriptors(characteristic, characteristic.descriptors ?? [], error))
+        parent.eventSubscriptions.receive(.discoveredDescriptors(characteristic, characteristic.descriptors ?? [], error))
         parent.delegate?.peripheral(parent, didDiscoverDescriptorsFor: characteristic, error: error)
     }
 
@@ -79,13 +79,13 @@ internal final class PeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
         guard let parent = parent else { return }
-        parent.eventSubscriptions.recieve(.updateNotificationState(characteristic, error))
+        parent.eventSubscriptions.receive(.updateNotificationState(characteristic, error))
         parent.delegate?.peripheral(parent, didUpdateNotificationStateFor: characteristic, error: error)
     }
 
     func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
         guard let parent = parent else { return }
-        parent.eventSubscriptions.recieve(.readRSSI(RSSI, error))
+        parent.eventSubscriptions.receive(.readRSSI(RSSI, error))
         parent.delegate?.peripheral(parent, didReadRSSI: RSSI, error: error)
     }
 

--- a/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
+++ b/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
@@ -165,7 +165,7 @@ final class LostConnectionPeripheralTests: CentralPeripheralTestCase {
     }
 
     @available(iOS 13, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
-    func testPeripheralSimultaniousDisconnectAndRead() async throws {
+    func testPeripheralSimultaneousDisconnectAndRead() async throws {
         try await withTimeout { [self] in
             try await central.waitUntilReady()
             peripheral = await central.scanForPeripherals().first!

--- a/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
+++ b/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
@@ -196,7 +196,8 @@ final class LostConnectionPeripheralTests: CentralPeripheralTestCase {
                 XCTAssertEqual(0, ran)
                 ran += 1
             }
-            peripheral.responseMap.recieve(key: characteristic.uuid, withValue: .success(.init([0xFF])))
+
+            peripheral.responseMap.receive(key: characteristic.uuid, withValue: .success(.init([0xFF])))
             peripheral.eventSubscriptions.receive(.didDisconnect(nil))
 
             #if swift(>=5.8)

--- a/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
+++ b/Tests/SwiftBluetoothTests/LostConnectionPeripheralTests.swift
@@ -197,7 +197,7 @@ final class LostConnectionPeripheralTests: CentralPeripheralTestCase {
                 ran += 1
             }
             peripheral.responseMap.recieve(key: characteristic.uuid, withValue: .success(.init([0xFF])))
-            peripheral.eventSubscriptions.recieve(.didDisconnect(nil))
+            peripheral.eventSubscriptions.receive(.didDisconnect(nil))
 
             #if swift(>=5.8)
             await self.fulfillment(of: [exp])


### PR DESCRIPTION
Rename some functions that contained spelling errors.  Where necessary mark the old spelling deprecated.